### PR TITLE
Fix broken action.yml, pointing to non-existing "bumpversion.js"

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,5 +14,5 @@ inputs:
     required: true
 runs:
       using: 'node12'
-      main: 'bumpversion.js'
+      main: 'dist/index.js'
 


### PR DESCRIPTION
This is just a hotfix, `action.yml` points to a wrong dist file.